### PR TITLE
Parameters to new_project enclosed in single quotes

### DIFF
--- a/sklearn-pipe/sklearn-project.ipynb
+++ b/sklearn-pipe/sklearn-project.ipynb
@@ -152,7 +152,7 @@
    "source": [
     "from mlrun import new_project, code_to_function\n",
     "project_dir = './project'\n",
-    "skproj = new_project(project_name, 'project_dir, init_git=True')"
+    "skproj = new_project(project_name, project_dir, init_git=True)"
    ]
   },
   {


### PR DESCRIPTION
Was
 new_project(project_name, 'project_dir, init_git=True')
Change to 
new_project(project_name, project_dir, init_git=True)"