### PR TITLE
[news-article-nlp] move cache directory from .cache -> /tmp 

### DIFF
--- a/news-article-nlp/news_article_nlp.ipynb
+++ b/news-article-nlp/news_article_nlp.ipynb
@@ -84,7 +84,9 @@
     "    \"python -m pip install transformers==4.11.3 newspaper3k==0.2.8 keybert~=0.7.0\",\n",
     "    \"python -c 'from transformers import pipeline; pipeline(\\\"summarization\\\")'\",\n",
     "    \"python -c 'from keybert import KeyBERT; KeyBERT()'\"\n",
-    "]"
+    "]\n",
+    "fn.set_env(\"SENTENCE_TRANSFORMERS_HOME\",\"/tmp\")\n",
+    "fn.set_env(\"TRANSFORMERS_CACHE\",\"/tmp\")"
    ]
   },
   {


### PR DESCRIPTION
for resolving security context override issue