### PR TITLE
[Docs] Add ipywidgets installation

### DIFF
--- a/tutorials/05-model-monitoring.ipynb
+++ b/tutorials/05-model-monitoring.ipynb
@@ -40,8 +40,7 @@
    "outputs": [],
    "source": [
     "# Install MLRun if not installed, run this only once (restart the notebook after the install !!!)\n",
-    "%pip install mlrun\n",
-    "%pip install tqdm"
+    "%pip install mlrun tqdm ipywidgets"
    ]
   },
   {


### PR DESCRIPTION
Using `tqdm.notebook` requires `ipywidgets` installation
[ML-3607](https://jira.iguazeng.com/browse/ML-3607)