### PR TITLE
[stocks-prediction] Fix long flush delay, `MLRunInvalidArgumentError`

### DIFF
--- a/howto/spark/spark-mlrun-describe.ipynb
+++ b/howto/spark/spark-mlrun-describe.ipynb
@@ -50,8 +50,8 @@
     }
    ],
    "source": [
-    "# install prerequsits \n",
-    "# prerequisits for the notebook is installing 2 packages yfinance yahoo_fin for uploading stocks data \n",
+    "# install prerequisites\n",
+    "# prerequisites for the notebook is installing 2 packages yfinance yahoo_fin for uploading stocks data \n",
     "import importlib.util\n",
     "import IPython\n",
     "\n",

--- a/stocks-prediction/01_ingest_news.ipynb
+++ b/stocks-prediction/01_ingest_news.ipynb
@@ -24,7 +24,7 @@
    "metadata": {},
    "source": [
     "> <b> Steps </b>\n",
-    "> * [project creation and prerequisits](#project-creation-and-prerequisits)\n",
+    "> * [project creation and prerequisites](#project-creation-and-prerequisites)\n",
     "> * [Deploying sentiment analysis serving function from the function marketplace](#Deploying-sentiment-analysis-serving-function-from-the-function-marketplace)\n",
     "> * [Creating a feature set and declaring the graph](#Creating-a-feature-set-and-declaring-the-graph)\n",
     "> * [Dummy ingestion, Deploying ingestion service and getting ingestion endpoint](#Dummy-ingestion,-Deploying-ingestion-service-and-getting-ingestion-endpoint)\n",
@@ -211,6 +211,7 @@
    ],
    "source": [
     "import mlrun.feature_store as fstore\n",
+    "from mlrun.datastore.targets import ParquetTarget\n",
     "\n",
     "# creating feature set\n",
     "news_set = fstore.FeatureSet(\"news\",\n",
@@ -225,7 +226,7 @@
     "    .to(name='wrap_event', handler='wrap_event') \\\n",
     "    .to(\"HuggingSentimentAnalysis\",handler= \"get_sentiment\", full_event=True)\n",
     "\n",
-    "news_set.set_targets(with_defaults=True) \n",
+    "news_set.set_targets([ParquetTarget(flush_after_seconds=5)], with_defaults=False)\n",
     "news_set.plot(rankdir=\"LR\", with_targets=True)"
    ]
   },

--- a/stocks-prediction/02_ingest_stocks.ipynb
+++ b/stocks-prediction/02_ingest_stocks.ipynb
@@ -162,6 +162,7 @@
    "source": [
     "import mlrun.feature_store as fstore\n",
     "from mlrun.feature_store.steps import DateExtractor, OneHotEncoder\n",
+    "from mlrun.datastore.targets import ParquetTarget\n",
     "import yahoo_fin.stock_info as si\n",
     "\n",
     "info_set = fstore.FeatureSet(\"stocks\", \n",
@@ -180,7 +181,7 @@
     "        .to(OneHotEncoder(mapping={'ticker2onehot':{ticker:str(idx) for idx,ticker in enumerate(si.tickers_sp500()[:n_tickers])}}))\\\n",
     "    \n",
     "# Setting default targets (nosql & parquet)\n",
-    "info_set.set_targets(with_defaults=True) \n",
+    "info_set.set_targets([ParquetTarget(flush_after_seconds=5)], with_defaults=False) \n",
     "info_set.plot(rankdir=\"LR\", with_targets=True)"
    ]
   },

--- a/stocks-prediction/03_train_model.ipynb
+++ b/stocks-prediction/03_train_model.ipynb
@@ -33,8 +33,8 @@
     }
    ],
    "source": [
-    "# install prerequsits \n",
-    "# prerequisits for the notebook is installing 2 packages yfinance yahoo_fin for uploading stocks data \n",
+    "# install prerequisites\n",
+    "# prerequisites for the notebook is installing 2 packages yfinance yahoo_fin for uploading stocks data \n",
     "import importlib.util\n",
     "import IPython\n",
     "\n",


### PR DESCRIPTION
* Fix long flush delay – [ML-4106](https://jira.iguazeng.com/browse/ML-4106)
* Fix `MLRunInvalidArgumentError` following https://github.com/mlrun/mlrun/pull/3786:
```
MLRunInvalidArgumentError: entity_timestamp_column param can not be specified without entity_rows param
```
* Fix misspellings of the word "prerequisites"