### PR TITLE
[mask detection] fixing 6984

### DIFF
--- a/mask-detection/1-training-and-evaluation.ipynb
+++ b/mask-detection/1-training-and-evaluation.ipynb
@@ -108,7 +108,7 @@
    "outputs": [],
    "source": [
     "if framework=='tf-keras':\n",
-    "    commands = ['pip install tensorflow~=2.9.0',\n",
+    "    commands = ['pip install tensorflow~=2.9.0 mlrun',\n",
     "                'pip install horovod==0.25.0']\n",
     "    builder_env = {'HOROVOD_WITH_MPI':'1', 'HOROVOD_WITH_TENSORFLOW':'1'}\n",
     "else:\n",


### PR DESCRIPTION
 cannot import name 'builder' from 'google.protobuf.internal'