### PR TITLE
[demos] Fix update demos [1.7.x]

### DIFF
--- a/update_demos.sh
+++ b/update_demos.sh
@@ -235,7 +235,7 @@ get_latest_tag() {
       # trying to find matching rc
       # case mlrun doesnt have an rc (its a release) and demos doesn't have matching release (fetching latest rc)
       if [ -z "$formatted_rc" ]; then # rc is ""
-        echo "${with_rc[*]}" | tr ' ' '\n' | sort -Vr | head -n 1
+        echo "${all_rcs[*]}" | tr ' ' '\n' | sort -Vr | head -n 1
         return
       fi
       # case mlrun does have an rc - return its matching demos rc

--- a/update_demos.sh
+++ b/update_demos.sh
@@ -252,6 +252,36 @@ get_latest_tag() {
     }
 
 # --------------------------------------------------------------------------------------------------------------------------------
+# Function to get compare current version with 1.7 Iversion when demos were introduced
+# --------------------------------------------------------------------------------------------------------------------------------
+
+is_newer_than_1_7() {
+  version="${1#v}"
+  base="${version%%-*}"  # Strip -rcX if present
+  rc="${version#"$base"}"
+
+  major=$(echo "$base" | cut -d. -f1)
+  minor=$(echo "$base" | cut -d. -f2)
+  major=${major:-0}
+  minor=${minor:-0}
+
+  # If rc is present, consider version as pre-release → not >= 1.7
+  if echo "$rc" | grep -q '^-' ; then
+    # pre-release version like -rc2
+    if [ "$major" -eq 1 ] && [ "$minor" -eq 7 ]; then
+      return 1  # not considered >= 1.7
+    fi
+  fi
+
+  if [ "$major" -gt 1 ]; then return 0; fi
+  if [ "$major" -eq 1 ] && [ "$minor" -gt 7 ]; then return 0; fi
+  if [ "$major" -eq 1 ] && [ "$minor" -eq 7 ]; then return 0; fi
+
+  return 1
+}
+
+
+# --------------------------------------------------------------------------------------------------------------------------------
 # Download tar file to a temporary folder
 # --------------------------------------------------------------------------------------------------------------------------------
 
@@ -323,7 +353,7 @@ branch=${latest_tag#refs/tags/}
 echo "Using branch ${branch} to download demos"
 temp_dir=$(mktemp -d /tmp/temp-get-demos.XXXXXXXXXX)
 # demos introduced to mlrun in 1.7.0
-if [[ "${branch}">"v1.7" ]]; then
+if is_newer_than_1_7 "$branch"; then
     tar_url="${git_base_url}/releases/download/${branch}/mlrun-demos.tar"
     download_tar_to_temp_dir "$tar_url" "$temp_dir"
     verify_update_demos "${temp_dir}" "${branch}"


### PR DESCRIPTION
the way comparison was happening between current branch and 1.7, was returning 1.10.X as < than 1.7 and that was the issue.